### PR TITLE
This resolved and issue with the resolver

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,3 @@
 [workspace]
-members = [
-    "src-tauri",
-    "src-ui",
-]
+resolver = "2"
+members = ["src-tauri", "src-ui"]


### PR DESCRIPTION
There is a broken build at the moment  see ( #2 ) but once that is fixed.
I want to clear this warning message.

Seen whilst running cargo audit.

warning: virtual workspace defaulting to `resolver = "1"` despite one or more workspace members being on edition 2021 which implies `resolver = "2"`
note: to keep the current resolver, specify `workspace.resolver = "1"` in the workspace root's manifest
note: to use the edition 2021 resolver, specify `workspace.resolver = "2"` in the workspace root's manifest
note: for more details see https://doc.rust-lang.org/cargo/reference/resolver.html#resolver-versions

